### PR TITLE
use default C++

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,8 +1,6 @@
 cmake_minimum_required(VERSION 3.0.2)
 project(log_view)
 
-add_compile_options(-std=c++11)
-
 find_package(catkin REQUIRED COMPONENTS
   roscpp
 )


### PR DESCRIPTION
When building in Ubuntu 22.04 I get

```
In file included from /usr/include/log4cxx/log4cxx.h:45,
                 from /usr/include/log4cxx/logstring.h:28,
                 from /usr/include/log4cxx/level.h:22,
                 from /home/lucasw/base_catkin_ws/src/ros/rosconsole/include/ros/console.h:46,
                 from /home/lucasw/base_catkin_ws/src/ros/ros_comm/clients/roscpp/include/ros/ros.h:40,
                 from /home/lucasw/catkin_ws/src/misc/log_view/include/log_view/datatypes.h:32,
                 from /home/lucasw/catkin_ws/src/misc/log_view/include/log_view/log_filter.h:36,
                 from /home/lucasw/catkin_ws/src/misc/log_view/src/log_filter.cpp:28:
/usr/include/log4cxx/boost-std-configuration.h:10:18: error: ‘shared_mutex’ in namespace ‘std’ does not name a type
   10 |     typedef std::shared_mutex shared_mutex;
      |                  ^~~~~~~~~~~~
/usr/include/log4cxx/boost-std-configuration.h:10:13: note: ‘std::shared_mutex’ is only available from C++17 onwards
   10 |     typedef std::shared_mutex shared_mutex;
      |             ^~~
/usr/include/log4cxx/boost-std-configuration.h:12:30: error: ‘shared_lock’ in namespace ‘std’ does not name a template type
   12 |     using shared_lock = std::shared_lock<T>;
      |                              ^~~~~~~~~~~
/usr/include/log4cxx/boost-std-configuration.h:12:25: note: ‘std::shared_lock’ is only available from C++14 onwards

```

Using the default 22.04 C++17 fixes this.  Noetic on 20.04 ought to use C++14 by default which should be fine.